### PR TITLE
New ExpandoObject for every IDataReader Read()

### DIFF
--- a/src/ChoETL.Parquet/ChoParquetWriter.cs
+++ b/src/ChoETL.Parquet/ChoParquetWriter.cs
@@ -562,8 +562,6 @@ namespace ChoETL
             ChoGuard.ArgumentNotNull(dr, "DataReader");
 
             DataTable schemaTable = dr.GetSchemaTable();
-            dynamic expando = new ExpandoObject();
-            var expandoDic = (IDictionary<string, object>)expando;
 
             Configuration.UseNestedKeyFormat = false;
 
@@ -585,7 +583,8 @@ namespace ChoETL
             var ordinals = Configuration.ParquetRecordFieldConfigurations.ToDictionary(c => c.Name, c => dr.HasColumn(c.Name) ? dr.GetOrdinal(c.Name) : -1);
             while (dr.Read())
             {
-                expandoDic.Clear();
+                dynamic expando = new ExpandoObject();
+                var expandoDic = (IDictionary<string, object>)expando;
 
                 foreach (var fc in ordinals)
                 {


### PR DESCRIPTION
Code fix for Issue #204 

- Instantiate new ExpandoObject reference in every IDataReader Road() loop
- Don't reuse this object reference as it results in all `private List<dynamic> _records` in `ChoParquetRecordWriter` to be referencing the same object and writing all duplicates to the Parquet output file