### PR TITLE
Fix issue with RightOf matching the last occurance rather the first

### DIFF
--- a/src/ChoETL/Common/ChoUtility.cs
+++ b/src/ChoETL/Common/ChoUtility.cs
@@ -1936,7 +1936,7 @@ namespace ChoETL
             if (searchText.IsNullOrWhiteSpace())
                 throw new ArgumentException("Invalid searchText passed.");
 
-            int index = source.LastIndexOf(searchText);
+            int index = source.IndexOf(searchText);
             if (index < 0)
                 return source;
             index = index + searchText.Length;

--- a/src/Test/ChoCSVReaderUnitTest.Core/FileNoHeadersParse.cs
+++ b/src/Test/ChoCSVReaderUnitTest.Core/FileNoHeadersParse.cs
@@ -1,0 +1,42 @@
+﻿using ChoETL;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ChoCSVReaderUnitTest.Core
+{
+    [TestFixture]
+    public class FileNoHeadersParse
+    {
+        [Test]
+        public void DuplicateCharBeforeSeparatorTest()
+        {
+            string csv = @"2,Tom,32,ThisShouldBeDescriptionValue";
+
+            var rec = ChoCSVReader.LoadText(csv)
+                .Configure(c => c.FileHeaderConfiguration.HasHeaderRecord = false)
+                .WithField("Id")
+                .WithField("Name")
+                .WithField("Age")
+                .WithField("Description")
+                .First();
+
+            Assert.IsNotNull(rec);
+            Assert.AreEqual("2", rec.Id);
+            Assert.AreEqual("Tom", rec.Name);
+            Assert.AreEqual("32", rec.Age);
+            Assert.AreEqual("ThisShouldBeDescriptionValue", rec.Description);
+        }
+
+        [Test]
+        public void RightOfExample()
+        {
+            string csv = @"2,Tom,32,RightOfShouldReturnFromTomNotThis";
+
+            var result = ChoUtility.RightOf(csv, "2,");
+            Assert.AreEqual("Tom,32,RightOfShouldReturnFromTomNotThis", result);
+        }
+    }
+}


### PR DESCRIPTION
ChoCSVReader uses ChoUtility.RightOf to go through a line removing fields as it goes.  It expects this to return all text after the first occurrence of the specified pattern, but it returns right of the last occurrence.  This causes ChoCSVReader to skip out fields when the field separator pattern appears in the line more than once.  

The FileNoHeadersParse unit tests demonstrate this and fail without the associated fix to RightOf.